### PR TITLE
Guilhermedias/path 3355 whatsapp

### DIFF
--- a/src/app/api/integration-export-support/route.ts
+++ b/src/app/api/integration-export-support/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthFromRequest } from "@/lib/server-auth";
+import { generateIntegrationToken } from "@/lib/integration-token";
+
+export async function GET(request: NextRequest) {
+	try {
+		const auth = await getAuthFromRequest(request);
+		if (!auth) {
+			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+		}
+
+		const { searchParams } = new URL(request.url);
+		const integrationKey = searchParams.get("integrationKey");
+
+		if (!integrationKey) {
+			return NextResponse.json(
+				{ error: "Integration key is required" },
+				{ status: 400 }
+			);
+		}
+
+		const token = await generateIntegrationToken(auth);
+
+		console.log(
+			`Making API request to check export support for: ${integrationKey}`
+		);
+		const response = await fetch(
+			`https://api.integration.app/integrations/${integrationKey}/actions/get-chats/export`,
+			{
+				method: "GET",
+				headers: {
+					Authorization: `Bearer ${token}`,
+					"Content-Type": "application/json",
+				},
+			}
+		);
+
+		console.log(`Response status for ${integrationKey}: ${response.status}`);
+
+		// If we get a 200 status, check if the response contains valid action data
+		if (response.status === 200) {
+			const data = await response.json();
+			console.log(`Response data for ${integrationKey}:`, data);
+
+			// Check if the response has the expected structure for a valid action
+			const isValidAction =
+				data && data.key === "get-chats" && data.type === "list-data-records";
+			console.log(`Is valid action for ${integrationKey}: ${isValidAction}`);
+			return NextResponse.json({ supportsExport: isValidAction });
+		}
+
+		// Return false for 404 or any other status
+		console.log(
+			`Export not supported for ${integrationKey} (status: ${response.status})`
+		);
+		return NextResponse.json({ supportsExport: false });
+	} catch (error) {
+		console.error("Error checking integration export support:", error);
+		return NextResponse.json(
+			{ error: "Failed to check export support" },
+			{ status: 500 }
+		);
+	}
+}

--- a/src/app/api/integration-export-support/route.ts
+++ b/src/app/api/integration-export-support/route.ts
@@ -37,23 +37,12 @@ export async function GET(request: NextRequest) {
 
 		console.log(`Response status for ${integrationKey}: ${response.status}`);
 
-		// If we get a 200 status, check if the response contains valid action data
-		if (response.status === 200) {
-			const data = await response.json();
-			console.log(`Response data for ${integrationKey}:`, data);
+		// Check if the response indicates support for export
+		// A 200 status means the endpoint exists and supports export
+		// A 404 status means the endpoint doesn't exist (no export support)
+		const supportsExport = response.status === 200;
 
-			// Check if the response has the expected structure for a valid action
-			const isValidAction =
-				data && data.key === "get-chats" && data.type === "list-data-records";
-			console.log(`Is valid action for ${integrationKey}: ${isValidAction}`);
-			return NextResponse.json({ supportsExport: isValidAction });
-		}
-
-		// Return false for 404 or any other status
-		console.log(
-			`Export not supported for ${integrationKey} (status: ${response.status})`
-		);
-		return NextResponse.json({ supportsExport: false });
+		return NextResponse.json({ supportsExport });
 	} catch (error) {
 		console.error("Error checking integration export support:", error);
 		return NextResponse.json(

--- a/src/app/api/integrations/import-new/route.ts
+++ b/src/app/api/integrations/import-new/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import connectDB from "@/lib/mongodb";
+import { UserPlatform } from "@/models/user-platform";
+import { getAuthFromRequest } from "@/lib/server-auth";
+
+export async function GET(request: NextRequest) {
+	try {
+		const auth = await getAuthFromRequest(request);
+		if (!auth) {
+			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+		}
+
+		const { searchParams } = new URL(request.url);
+		const platformId = searchParams.get("platformId");
+
+		if (!platformId) {
+			return NextResponse.json(
+				{ error: "Platform ID is required" },
+				{ status: 400 }
+			);
+		}
+
+		await connectDB();
+
+		const userPlatform = await UserPlatform.findOne({
+			platformId: platformId,
+			customerId: auth.customerId,
+		});
+
+		return NextResponse.json({
+			success: true,
+			platformId,
+			importNew: userPlatform ? userPlatform.importNew : true, // Default to true if no record exists
+			exists: !!userPlatform,
+		});
+	} catch (error) {
+		console.error("Error getting import new setting:", error);
+		return NextResponse.json(
+			{ error: "Failed to get import new setting" },
+			{ status: 500 }
+		);
+	}
+}
+
+export async function POST(request: NextRequest) {
+	try {
+		const auth = await getAuthFromRequest(request);
+		if (!auth) {
+			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+		}
+
+		const { platformId, importNew } = await request.json();
+
+		if (typeof platformId !== "string" || typeof importNew !== "boolean") {
+			return NextResponse.json(
+				{ error: "Invalid parameters" },
+				{ status: 400 }
+			);
+		}
+
+		await connectDB();
+
+		// Update or create the user platform settings
+		await UserPlatform.findOneAndUpdate(
+			{
+				platformId: platformId,
+				customerId: auth.customerId,
+			},
+			{
+				importNew: importNew,
+			},
+			{
+				upsert: true, // Create if doesn't exist
+				new: true,
+			}
+		);
+
+		console.log(
+			`✅ Updated importNew setting for platform ${platformId}: ${importNew}`
+		);
+
+		return NextResponse.json({
+			success: true,
+			message: `Import new setting updated to ${importNew}`,
+		});
+	} catch (error) {
+		console.error("Error updating import new setting:", error);
+		return NextResponse.json(
+			{ error: "Failed to update import new setting" },
+			{ status: 500 }
+		);
+	}
+}

--- a/src/app/api/messages/receive/route.ts
+++ b/src/app/api/messages/receive/route.ts
@@ -3,6 +3,8 @@ import connectDB from "@/lib/mongodb";
 import { Message } from "@/models/message";
 import { Chat } from "@/models/chat";
 import { UserPlatform } from "@/models/user-platform";
+import { getIntegrationClient } from "@/lib/integration-app-client";
+import type { AuthCustomer } from "@/lib/auth";
 
 interface IncomingMessagePayload {
 	externalMessageId: string;
@@ -17,6 +19,67 @@ interface IncomingMessagePayload {
 		platformName?: string;
 		integrationId?: string;
 	};
+}
+
+interface ChatRecord {
+	id?: string;
+	name?: string;
+	title?: string;
+	subject?: string;
+	fields?: {
+		id?: string;
+		name?: string;
+	};
+	rawFields?: {
+		id?: string;
+		name?: string;
+	};
+}
+
+// Function to get chat name from available chats
+async function getChatName(
+	chatId: string,
+	integrationId: string,
+	auth: AuthCustomer
+): Promise<string> {
+	try {
+		const client = await getIntegrationClient(auth);
+
+		// Get available chats from the integration
+		const chatsResult = await client
+			.connection(integrationId)
+			.action("get-chats")
+			.run({
+				cursor: "", // Start from beginning
+			});
+
+		if (chatsResult.output?.records) {
+			const chat = chatsResult.output.records.find(
+				(chat: ChatRecord) =>
+					chat.id === chatId ||
+					chat.fields?.id === chatId ||
+					chat.rawFields?.id === chatId
+			);
+
+			if (chat) {
+				const chatName =
+					chat.fields?.name ||
+					chat.rawFields?.name ||
+					chat.name ||
+					chat.title ||
+					chat.subject ||
+					"Unnamed Chat";
+
+				console.log(`✅ Found chat name for ${chatId}: ${chatName}`);
+				return chatName;
+			}
+		}
+	} catch (error) {
+		console.error(`❌ Error fetching chat name for ${chatId}:`, error);
+	}
+
+	// Fallback to generic name if we can't fetch the real name
+	return `Chat ${chatId}`;
 }
 
 export async function POST(request: NextRequest) {
@@ -49,23 +112,35 @@ export async function POST(request: NextRequest) {
 		await connectDB();
 
 		// Extract data from the payload
-		const {
-			id,
-			content,
-			ownerId,
-			ownerName,
-			chatId,
-			timestamp,
-			platformName = "Unknown",
-			integrationId = "unknown",
-		} = data;
+		const { id, content, ownerId, ownerName, chatId, timestamp, platformName } =
+			data;
 
-		// Use the provided integrationId or fallback to platformName
-		let actualIntegrationId =
-			integrationId !== "unknown" ? integrationId : platformName.toLowerCase();
+		// Ensure platformName has a value
+		const actualPlatformName = platformName || "Unknown";
+
+		// Look up the integration information from UserPlatform using customerId and platformName
+		const userPlatform = await UserPlatform.findOne({
+			customerId: customerId,
+			platformName: actualPlatformName,
+		});
+
+		// Use the connectionId from UserPlatform as the integrationId
+		let actualIntegrationId = "unknown";
+		if (userPlatform) {
+			actualIntegrationId = userPlatform.connectionId;
+			console.log(
+				`✅ Found UserPlatform record for ${actualPlatformName}: connectionId = ${actualIntegrationId}`
+			);
+		} else {
+			console.log(
+				`⚠️ No UserPlatform record found for customerId: ${customerId}, platformName: ${actualPlatformName}`
+			);
+			// Fallback to platformName.toLowerCase() if no UserPlatform record exists
+			actualIntegrationId = actualPlatformName.toLowerCase();
+		}
 
 		console.log(
-			`🔍 Using integration ID: ${actualIntegrationId} for platform: ${platformName}`
+			`🔍 Using integration ID: ${actualIntegrationId} for platform: ${actualPlatformName}`
 		);
 
 		// Generate a unique message ID if not provided
@@ -90,37 +165,44 @@ export async function POST(request: NextRequest) {
 		console.log(`Raw timestamp: ${timestamp}`);
 		console.log(`Formatted timestamp: ${formattedTimestamp}`);
 
-		// Check if we already have this message by externalMessageId
+		// Check if we already have this message by externalMessageId and customerId
 		const existingMessage = await Message.findOne({
 			externalMessageId: externalMessageId,
+			customerId: customerId,
 		});
 
 		if (existingMessage) {
 			console.log(
-				`Message with externalMessageId ${externalMessageId} already exists, skipping import`
+				`Message with externalMessageId ${externalMessageId} already exists for customer ${customerId}, skipping import`
 			);
 			return NextResponse.json({
 				success: true,
-				message: "Message already exists",
+				message: "Message already exists for this customer",
 			});
 		}
 
 		// Find or create the chat
 		let chat = await Chat.findOne({ id: chatId, customerId });
 		if (!chat) {
-			// Check if this platform has importNew enabled
-			const userPlatform = await UserPlatform.findOne({
-				platformId: actualIntegrationId, // Use the standardized platformId
-				customerId: customerId,
-			});
+			// Use the userPlatform we already found above, or do a fallback lookup
+			let importNewEnabled = true; // Default to true
 
-			// Default to true if no UserPlatform record exists (new connection)
-			// Only false if explicitly set to false
-			const importNewEnabled = userPlatform ? userPlatform.importNew : true;
+			if (userPlatform) {
+				importNewEnabled = userPlatform.importNew;
+			} else {
+				// Fallback lookup using platformName
+				const fallbackUserPlatform = await UserPlatform.findOne({
+					platformId: actualPlatformName.toLowerCase(),
+					customerId: customerId,
+				});
+				importNewEnabled = fallbackUserPlatform
+					? fallbackUserPlatform.importNew
+					: true;
+			}
 
 			if (!importNewEnabled) {
 				console.log(
-					`❌ Chat ${chatId} not found and importNew is disabled for platform ${actualIntegrationId}`
+					`❌ Chat ${chatId} not found and importNew is disabled for platform ${actualPlatformName}`
 				);
 				return NextResponse.json(
 					{
@@ -131,11 +213,17 @@ export async function POST(request: NextRequest) {
 				);
 			}
 
+			// Get the actual chat name from the integration
+			const chatName = await getChatName(chatId, actualIntegrationId, {
+				customerId,
+				customerName: null,
+			});
+
 			// Create a new chat if importNew is enabled
 			chat = await Chat.create({
 				id: chatId,
-				name: `Chat ${chatId}`,
-				platformName: platformName,
+				name: chatName,
+				platformName: actualPlatformName,
 				integrationId: actualIntegrationId,
 				lastMessage: content,
 				lastMessageTime: formattedTimestamp,
@@ -143,17 +231,44 @@ export async function POST(request: NextRequest) {
 				customerId,
 				importNew: true, // Set importNew to true for new chats
 			});
-			console.log(`✅ Created new chat with importNew enabled: ${chatId}`);
-		} else {
-			// Update chat with latest message info
-			await Chat.findOneAndUpdate(
-				{ id: chatId, customerId },
-				{
-					lastMessage: content,
-					lastMessageTime: formattedTimestamp,
-					updatedAt: new Date(),
-				}
+			console.log(
+				`✅ Created new chat with importNew enabled: ${chatId} (${chatName})`
 			);
+		} else {
+			// Update chat with latest message info and fix integrationId if needed
+			const updateData: {
+				lastMessage: string;
+				lastMessageTime: string;
+				updatedAt: Date;
+				integrationId?: string;
+				platformName?: string;
+				name?: string;
+			} = {
+				lastMessage: content,
+				lastMessageTime: formattedTimestamp,
+				updatedAt: new Date(),
+			};
+
+			// Fix integrationId if it's "unknown" or doesn't match
+			if (
+				chat.integrationId === "unknown" ||
+				chat.integrationId !== actualIntegrationId
+			) {
+				console.log(
+					`🔧 Fixing chat integrationId from "${chat.integrationId}" to "${actualIntegrationId}"`
+				);
+				updateData.integrationId = actualIntegrationId;
+				updateData.platformName = actualPlatformName;
+
+				// Also update the chat name if we're fixing the integration
+				const chatName = await getChatName(chatId, actualIntegrationId, {
+					customerId,
+					customerName: null,
+				});
+				updateData.name = chatName;
+			}
+
+			await Chat.findOneAndUpdate({ id: chatId, customerId }, updateData);
 		}
 
 		// Save the incoming message to MongoDB
@@ -165,7 +280,7 @@ export async function POST(request: NextRequest) {
 			timestamp: formattedTimestamp,
 			chatId: chatId,
 			integrationId: actualIntegrationId,
-			platformName: platformName,
+			platformName: actualPlatformName,
 			messageType: "third-party", // Mark as incoming message
 			externalMessageId: externalMessageId,
 			status: "sent", // Incoming messages are already sent on the external platform

--- a/src/app/api/messages/sync/route.ts
+++ b/src/app/api/messages/sync/route.ts
@@ -334,7 +334,9 @@ export async function POST(request: NextRequest) {
 										// by comparing the sender with our stored external user IDs
 										const userPlatform = await UserPlatform.findOne({
 											customerId: auth.customerId,
-											platformId: connection.id,
+											platformId:
+												connection.integration?.key ||
+												connection.name.toLowerCase(),
 											externalUserId: sender,
 										});
 

--- a/src/app/api/messages/sync/route.ts
+++ b/src/app/api/messages/sync/route.ts
@@ -50,12 +50,30 @@ export async function POST(request: NextRequest) {
 		const connectionsResponse = await client.connections.find();
 		let connections = connectionsResponse.items || [];
 
+		console.log(
+			`🔍 Available connections:`,
+			connections.map((c) => ({
+				id: c.id,
+				name: c.name,
+				integrationKey: c.integration?.key,
+			}))
+		);
+		console.log(`🔍 Requested integrationId:`, integrationId);
+
 		// Filter by integration ID if provided
 		if (integrationId) {
 			connections = connections.filter(
 				(connection) => connection.id === integrationId
 			);
 			console.log(`🔍 Filtering sync to integration: ${integrationId}`);
+			console.log(
+				`🔍 Filtered connections:`,
+				connections.map((c) => ({
+					id: c.id,
+					name: c.name,
+					integrationKey: c.integration?.key,
+				}))
+			);
 		}
 
 		if (connections.length === 0) {

--- a/src/app/api/user-platform/cleanup/route.ts
+++ b/src/app/api/user-platform/cleanup/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+import connectDB from "@/lib/mongodb";
+import { UserPlatform } from "@/models/user-platform";
+import { getAuthFromRequest } from "@/lib/server-auth";
+
+export async function POST(request: NextRequest) {
+	try {
+		const auth = getAuthFromRequest(request);
+		if (!auth.customerId) {
+			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+		}
+
+		await connectDB();
+
+		// Find all UserPlatform records for this customer
+		const allRecords = await UserPlatform.find({
+			customerId: auth.customerId,
+		}).sort({ createdAt: 1 });
+
+		console.log(
+			`Found ${allRecords.length} UserPlatform records for customer ${auth.customerId}`
+		);
+
+		const results = [];
+		const processedPlatformIds = new Set();
+
+		// Process each record
+		for (const record of allRecords) {
+			// Determine the correct platformId based on platformName
+			let correctPlatformId = record.platformId;
+
+			// Map platform names to standard platform IDs
+			if (record.platformName?.toLowerCase().includes("slack")) {
+				correctPlatformId = "slack";
+			} else if (record.platformName?.toLowerCase().includes("whatsapp")) {
+				correctPlatformId = "whatsapp";
+			} else if (record.platformName?.toLowerCase().includes("discord")) {
+				correctPlatformId = "discord";
+			} else {
+				// Use platformName as fallback
+				correctPlatformId =
+					record.platformName?.toLowerCase() || record.platformId;
+			}
+
+			const platformKey = `${correctPlatformId}-${auth.customerId}`;
+
+			if (processedPlatformIds.has(platformKey)) {
+				// This is a duplicate, delete it
+				console.log(
+					`🗑️ Deleting duplicate record for platform ${correctPlatformId}: ${record._id}`
+				);
+				await UserPlatform.findByIdAndDelete(record._id);
+				results.push({
+					action: "deleted",
+					platformId: correctPlatformId,
+					recordId: record._id,
+					reason: "duplicate",
+				});
+			} else {
+				// First occurrence of this platformId, keep it but ensure importNew is true and platformId is correct
+				processedPlatformIds.add(platformKey);
+
+				const updates: any = {};
+				let needsUpdate = false;
+
+				if (record.importNew === false) {
+					updates.importNew = true;
+					needsUpdate = true;
+				}
+
+				if (record.platformId !== correctPlatformId) {
+					updates.platformId = correctPlatformId;
+					needsUpdate = true;
+				}
+
+				if (needsUpdate) {
+					console.log(
+						`✅ Updating record for platform ${correctPlatformId}: ${record._id}`,
+						updates
+					);
+					await UserPlatform.findByIdAndUpdate(record._id, updates);
+					results.push({
+						action: "updated",
+						platformId: correctPlatformId,
+						recordId: record._id,
+						reason: "standardized platformId and importNew",
+					});
+				} else {
+					results.push({
+						action: "kept",
+						platformId: correctPlatformId,
+						recordId: record._id,
+						reason: "already correct",
+					});
+				}
+			}
+		}
+
+		// Get final count
+		const finalCount = await UserPlatform.countDocuments({
+			customerId: auth.customerId,
+		});
+
+		return NextResponse.json({
+			success: true,
+			message: `Cleanup completed. ${finalCount} records remaining.`,
+			results,
+			processed: allRecords.length,
+			finalCount,
+		});
+	} catch (error) {
+		console.error("Error cleaning up UserPlatform records:", error);
+		return NextResponse.json(
+			{ error: "Failed to cleanup UserPlatform records" },
+			{ status: 500 }
+		);
+	}
+}

--- a/src/app/api/user-platform/cleanup/route.ts
+++ b/src/app/api/user-platform/cleanup/route.ts
@@ -60,7 +60,10 @@ export async function POST(request: NextRequest) {
 				// First occurrence of this platformId, keep it but ensure importNew is true and platformId is correct
 				processedPlatformIds.add(platformKey);
 
-				const updates: any = {};
+				const updates: {
+					importNew?: boolean;
+					platformId?: string;
+				} = {};
 				let needsUpdate = false;
 
 				if (record.importNew === false) {

--- a/src/app/api/user-platform/fetch/route.ts
+++ b/src/app/api/user-platform/fetch/route.ts
@@ -110,23 +110,31 @@ export async function POST(request: NextRequest) {
 				await UserPlatform.findOneAndUpdate(
 					{
 						customerId: auth.customerId,
-						platformId: connection.id,
+						platformId:
+							connection.integration?.key || connection.name.toLowerCase(),
 					},
 					{
 						customerId: auth.customerId, // Our internal customer ID
-						platformId: connection.id,
+						platformId:
+							connection.integration?.key || connection.name.toLowerCase(),
 						platformName: platformName, // Use platform name from response
 						externalUserId, // External platform's user ID (e.g., "U0976R40534" for Slack)
 						externalUserName,
 						externalUserEmail,
 						connectionId: connection.id,
+						importNew: true, // Explicitly set importNew to true for new connections
 						lastSynced: new Date(),
 					},
-					{ upsert: true, new: true }
+					{
+						upsert: true,
+						new: true,
+						setDefaultsOnInsert: true, // Ensure defaults are set on new documents
+					}
 				);
 
 				results.push({
-					platformId: connection.id,
+					platformId:
+						connection.integration?.key || connection.name.toLowerCase(),
 					platformName: platformName, // Use platform name from response
 					externalUserId,
 					externalUserName,
@@ -154,7 +162,8 @@ export async function POST(request: NextRequest) {
 				}
 
 				results.push({
-					platformId: connection.id,
+					platformId:
+						connection.integration?.key || connection.name.toLowerCase(),
 					platformName: connection.name,
 					success: false,
 					error: errorMessage,

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useState, useCallback, useMemo, useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { useAuth } from "@/app/auth-provider";
 import { useChats } from "@/hooks/use-chats";
 import { useMessages } from "@/hooks/use-messages";
 import { useSyncMessages } from "@/hooks/use-sync-messages";
@@ -15,21 +13,10 @@ import { SyncChatsDialog } from "@/components/sync-chats-dialog";
 import { IntegrationsDialog } from "@/components/integrations-dialog";
 import { DeleteChatDialog } from "@/components/delete-chat-dialog";
 import { Button } from "@/components/ui/button";
-import {
-	MessageSquare,
-	Download,
-	Loader2,
-	Plus,
-	X,
-	MessageCircle,
-} from "lucide-react";
+import { MessageSquare, Loader2, Plus, X, MessageCircle } from "lucide-react";
 import type { Message } from "@/types/message";
 import { ensureAuth } from "@/lib/auth";
-import {
-	deleteChat,
-	sendMessageToThirdParty,
-	validateMessage,
-} from "@/lib/message-api";
+import { sendMessageToThirdParty, validateMessage } from "@/lib/message-api";
 import { SyncButton } from "@/components/sync-button";
 
 // Define ConnectedApp type to match the sync dialog
@@ -37,6 +24,18 @@ interface ConnectedApp {
 	key: string;
 	name: string;
 	logoUri?: string;
+	connection?: {
+		id: string;
+	};
+	integration?: {
+		key: string;
+	};
+}
+
+// Define Integration type to match the integration context
+interface Integration {
+	key: string;
+	name: string;
 	connection?: {
 		id: string;
 	};
@@ -183,13 +182,13 @@ export default function MessagesPage() {
 
 	// Helper function to get standardized platformId
 	const getStandardizedPlatformId = (
-		integration: ConnectedApp | any
+		integration: ConnectedApp | Integration
 	): string => {
 		console.log("🔍 getStandardizedPlatformId input:", integration);
 
 		// Try to get the integration key from various possible locations
 		const platformId =
-			(integration as any).integration?.key ||
+			integration.integration?.key ||
 			integration.key ||
 			integration.name?.toLowerCase() ||
 			"unknown";
@@ -245,10 +244,7 @@ export default function MessagesPage() {
 		console.log("🔍 Integration object:", integration);
 		console.log("🔍 Integration key:", integration.key);
 		console.log("🔍 Integration connection:", integration.connection);
-		console.log(
-			"🔍 Integration integration:",
-			(integration as any).integration
-		);
+		console.log("🔍 Integration integration:", integration.integration);
 
 		// Use the standardized platformId (integration key) for UserPlatform operations
 		const platformId = getStandardizedPlatformId(integration);
@@ -478,7 +474,7 @@ export default function MessagesPage() {
 					isSyncing={isSyncing}
 					lastSyncTime={lastSyncTime}
 					status={status}
-					integrationName={selectedIntegration?.name}
+					integrationName={selectedIntegration?.name || undefined}
 					integrationKey={selectedIntegration?.key}
 					isDisabled={
 						selectedIntegration?.key
@@ -618,7 +614,7 @@ export default function MessagesPage() {
 								isLoading={chatsLoading}
 								searchQuery={chatSearchQuery}
 								onSearchChange={handleSearchChange}
-								selectedIntegrationKey={selectedIntegration?.key}
+								selectedIntegrationKey={selectedIntegration?.key || undefined}
 								status={status}
 								isDisabled={
 									selectedIntegration?.key

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -619,6 +619,7 @@ export default function MessagesPage() {
 								searchQuery={chatSearchQuery}
 								onSearchChange={handleSearchChange}
 								selectedIntegrationKey={selectedIntegration?.key}
+								status={status}
 								isDisabled={
 									selectedIntegration?.key
 										? exportSupportMap[selectedIntegration.key] === false

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -1,29 +1,49 @@
 "use client";
 
 import { useState, useCallback, useMemo, useEffect } from "react";
-import { useMessages } from "@/hooks/use-messages";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/app/auth-provider";
 import { useChats } from "@/hooks/use-chats";
+import { useMessages } from "@/hooks/use-messages";
 import { useSyncMessages } from "@/hooks/use-sync-messages";
-import { Message } from "@/types/message";
-import { sendMessageToThirdParty, validateMessage } from "@/lib/message-api";
-import { ensureAuth } from "@/lib/auth";
-import { ChatscopeChat } from "@/components/chatscope-chat";
-import { ChatListSection } from "@/components/chat-list-section";
-import { Sidebar } from "@/components/sidebar";
-import { Button } from "@/components/ui/button";
-import {
-	MessageCircle,
-	Download,
-	Loader2,
-	X,
-	Plus,
-	MessageSquare,
-} from "lucide-react";
 import { useIntegrationContext } from "@/contexts/integration-context";
-import { SyncChatsDialog } from "@/components/sync-chats-dialog";
 import { useIntegrations } from "@integration-app/react";
+import { Sidebar } from "@/components/sidebar";
+import { ChatListSection } from "@/components/chat-list-section";
+import { ChatscopeChat } from "@/components/chatscope-chat";
+import { SyncChatsDialog } from "@/components/sync-chats-dialog";
 import { IntegrationsDialog } from "@/components/integrations-dialog";
 import { DeleteChatDialog } from "@/components/delete-chat-dialog";
+import { Button } from "@/components/ui/button";
+import {
+	MessageSquare,
+	Download,
+	Loader2,
+	Plus,
+	X,
+	MessageCircle,
+} from "lucide-react";
+import type { Message } from "@/types/message";
+import { ensureAuth } from "@/lib/auth";
+import {
+	deleteChat,
+	sendMessageToThirdParty,
+	validateMessage,
+} from "@/lib/message-api";
+import { SyncButton } from "@/components/sync-button";
+
+// Define ConnectedApp type to match the sync dialog
+interface ConnectedApp {
+	key: string;
+	name: string;
+	logoUri?: string;
+	connection?: {
+		id: string;
+	};
+	integration?: {
+		key: string;
+	};
+}
 
 export default function MessagesPage() {
 	// Hooks
@@ -35,9 +55,16 @@ export default function MessagesPage() {
 	const { chats, isLoading: chatsLoading, mutate: refreshChats } = useChats();
 	const { syncMessages, isSyncing, lastSyncTime, status, error } =
 		useSyncMessages();
-	const { selectedIntegration, setSelectedIntegration } =
-		useIntegrationContext();
 	const { integrations } = useIntegrations();
+	const { selectedIntegration, setSelectedIntegration, exportSupportMap } =
+		useIntegrationContext();
+	const [isIntegrationsDialogOpen, setIsIntegrationsDialogOpen] =
+		useState(false);
+	const [isDeleteChatDialogOpen, setIsDeleteChatDialogOpen] = useState(false);
+	const [chatToDelete, setChatToDelete] = useState<{
+		id: string;
+		name: string;
+	} | null>(null);
 
 	// Get connected integrations
 	const connectedIntegrations = integrations.filter(
@@ -69,13 +96,6 @@ export default function MessagesPage() {
 	const [selectedChatId, setSelectedChatId] = useState<string | undefined>();
 	const [chatSearchQuery, setChatSearchQuery] = useState("");
 	const [isSyncDialogOpen, setIsSyncDialogOpen] = useState(false);
-	const [isIntegrationsDialogOpen, setIsIntegrationsDialogOpen] =
-		useState(false);
-	const [isDeleteChatDialogOpen, setIsDeleteChatDialogOpen] = useState(false);
-	const [chatToDelete, setChatToDelete] = useState<{
-		id: string;
-		name: string;
-	} | null>(null);
 
 	// Stable callback for search
 	const handleSearchChange = useCallback((value: string) => {
@@ -161,6 +181,23 @@ export default function MessagesPage() {
 		[updateMessageStatus, mutateMessages]
 	);
 
+	// Helper function to get standardized platformId
+	const getStandardizedPlatformId = (
+		integration: ConnectedApp | any
+	): string => {
+		console.log("🔍 getStandardizedPlatformId input:", integration);
+
+		// Try to get the integration key from various possible locations
+		const platformId =
+			(integration as any).integration?.key ||
+			integration.key ||
+			integration.name?.toLowerCase() ||
+			"unknown";
+
+		console.log("🔍 getStandardizedPlatformId result:", platformId);
+		return platformId;
+	};
+
 	// Event handlers
 	const handleSync = async () => {
 		console.log(
@@ -172,23 +209,87 @@ export default function MessagesPage() {
 			selectedIntegration?.connection?.id
 		);
 		console.log("🔍 selectedIntegration?.key:", selectedIntegration?.key);
+		console.log(
+			"🔍 Current sync status - isSyncing:",
+			isSyncing,
+			"status:",
+			status
+		);
 
 		// Always open the sync dialog - it will handle app selection if needed
 		console.log("📱 Opening sync dialog");
 		setIsSyncDialogOpen(true);
 	};
 
-	const handleSyncSelectedChats = async (selectedChatIds: string[]) => {
+	const handleSyncSelectedChats = async (
+		selectedChatIds: string[],
+		importNew: boolean,
+		selectedApp?: ConnectedApp
+	) => {
+		console.log("🔍 handleSyncSelectedChats called with:");
+		console.log("🔍 selectedChatIds:", selectedChatIds);
+		console.log("🔍 importNew:", importNew);
+		console.log("🔍 selectedApp:", selectedApp);
+		console.log("🔍 selectedIntegration:", selectedIntegration);
+
+		// Use selectedApp from dialog if provided, otherwise fall back to global selectedIntegration
+		const integration = selectedApp || selectedIntegration;
+
+		console.log("🔍 Final integration object:", integration);
+
+		if (!integration) {
+			console.error("No integration selected for sync");
+			return;
+		}
+
+		console.log("🔍 Integration object:", integration);
+		console.log("🔍 Integration key:", integration.key);
+		console.log("🔍 Integration connection:", integration.connection);
+		console.log(
+			"🔍 Integration integration:",
+			(integration as any).integration
+		);
+
+		// Use the standardized platformId (integration key) for UserPlatform operations
+		const platformId = getStandardizedPlatformId(integration);
+
+		// Use the connection ID for sync operations (this is what the sync API expects)
+		const connectionId = integration.connection?.id || integration.key;
+
+		console.log("🔍 Using platformId:", platformId);
+		console.log("🔍 Using connectionId:", connectionId);
+
+		if (!connectionId) {
+			console.error("No integration connection ID found");
+			console.error(
+				"Integration object:",
+				JSON.stringify(integration, null, 2)
+			);
+			return;
+		}
+
 		try {
-			console.log("🚀 Syncing selected chats:", selectedChatIds);
-			const integrationId = selectedIntegration?.connection?.id;
-			const result = await syncMessages(integrationId, selectedChatIds);
-			console.log("📊 Sync result:", result);
-			await Promise.all([mutateMessages(), refreshChats()]);
-			console.log("🔄 Data refreshed after sync");
+			console.log("🔍 Syncing selected chats:", selectedChatIds);
+			console.log("🔍 Import new messages:", importNew);
+
+			// Use connectionId for sync API (this is what it expects)
+			const result = await syncMessages(connectionId, selectedChatIds);
+
+			// Note: importNew setting is managed through the sync dialog UI
+			// We don't need to update it here during sync operations
+			console.log("🔍 Sync completed - importNew setting managed through UI");
+
+			console.log("✅ Sync completed:", result);
+
+			// Refresh data immediately after sync completion
+			console.log("🔄 Refreshing data after sync...");
+			await Promise.all([
+				refreshChats(), // Refresh chats list
+				mutateMessages(), // Refresh messages
+			]);
+			console.log("✅ Data refresh completed");
 		} catch (error) {
-			console.error("💥 Failed to sync selected chats:", error);
-			throw error;
+			console.error("❌ Sync failed:", error);
 		}
 	};
 
@@ -371,33 +472,25 @@ export default function MessagesPage() {
 					</Button>
 				)}
 			</div>
-			<div className="flex space-x-2">
-				<Button
-					onClick={handleSync}
-					disabled={isSyncing}
-					variant="outline"
-					className="bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700"
-					title={
-						lastSyncTime
-							? `Last synced: ${new Date(lastSyncTime).toLocaleString()}`
-							: "No previous sync"
+			<div className="flex flex-col items-end space-y-2">
+				<SyncButton
+					onSync={handleSync}
+					isSyncing={isSyncing}
+					lastSyncTime={lastSyncTime}
+					status={status}
+					integrationName={selectedIntegration?.name}
+					integrationKey={selectedIntegration?.key}
+					isDisabled={
+						selectedIntegration?.key
+							? exportSupportMap[selectedIntegration.key] === false
+							: false
 					}
-				>
-					{isSyncing ? (
-						<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-					) : (
-						<Download className="mr-2 h-4 w-4" />
-					)}
-					{isSyncing
-						? `Syncing... (${status})`
-						: selectedIntegration
-						? `Sync ${selectedIntegration.name}`
-						: "Sync Messages"}
-				</Button>
+					showMessage={true}
+				/>
 
 				{/* Error display */}
 				{error && (
-					<div className="text-red-600 dark:text-red-400 text-sm mt-2">
+					<div className="text-red-600 dark:text-red-400 text-sm">
 						Error: {error}
 					</div>
 				)}
@@ -525,6 +618,12 @@ export default function MessagesPage() {
 								isLoading={chatsLoading}
 								searchQuery={chatSearchQuery}
 								onSearchChange={handleSearchChange}
+								selectedIntegrationKey={selectedIntegration?.key}
+								isDisabled={
+									selectedIntegration?.key
+										? exportSupportMap[selectedIntegration.key] === false
+										: false
+								}
 							/>
 							<ChatViewSection />
 						</div>
@@ -541,11 +640,10 @@ export default function MessagesPage() {
 					console.log("🔒 Closing sync dialog");
 					setIsSyncDialogOpen(false);
 				}}
-				integrationKey={
-					selectedIntegration?.key || selectedIntegration?.connection?.id
-				}
-				integrationName={selectedIntegration?.name}
+				integrationKey={selectedIntegration?.key || null}
+				integrationName={selectedIntegration?.name || undefined}
 				onSyncSelected={handleSyncSelectedChats}
+				selectedIntegration={selectedIntegration}
 			/>
 
 			{/* Integrations Dialog */}

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -244,7 +244,6 @@ export default function MessagesPage() {
 		console.log("🔍 Integration object:", integration);
 		console.log("🔍 Integration key:", integration.key);
 		console.log("🔍 Integration connection:", integration.connection);
-		console.log("🔍 Integration integration:", integration.integration);
 
 		// Use the standardized platformId (integration key) for UserPlatform operations
 		const platformId = getStandardizedPlatformId(integration);
@@ -606,7 +605,7 @@ export default function MessagesPage() {
 						<div className="grid grid-cols-1 lg:grid-cols-3 gap-6 h-[600px]">
 							<ChatListSection
 								chats={filteredChats}
-								selectedChatId={selectedChatId}
+								selectedChatId={selectedChatId || null}
 								onChatSelect={setSelectedChatId}
 								onChatDelete={handleDeleteChat}
 								onSyncChats={handleSync}

--- a/src/components/chat-list-section.tsx
+++ b/src/components/chat-list-section.tsx
@@ -15,6 +15,7 @@ interface ChatListSectionProps {
 	onSearchChange?: (value: string) => void;
 	selectedIntegrationKey?: string | undefined;
 	isDisabled?: boolean;
+	status?: string;
 }
 
 export function ChatListSection({
@@ -29,6 +30,7 @@ export function ChatListSection({
 	onSearchChange,
 	selectedIntegrationKey,
 	isDisabled = false,
+	status,
 }: ChatListSectionProps) {
 	return (
 		<div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 flex flex-col h-full min-h-0">
@@ -61,6 +63,7 @@ export function ChatListSection({
 					searchQuery={searchQuery}
 					selectedIntegrationKey={selectedIntegrationKey}
 					isDisabled={isDisabled}
+					status={status}
 				/>
 			</div>
 		</div>

--- a/src/components/chat-list-section.tsx
+++ b/src/components/chat-list-section.tsx
@@ -43,7 +43,7 @@ export function ChatListSection({
 			</div>
 
 			{/* Search */}
-			<div className="p-4 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
+			<div className="p-1 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
 				<ChatSearch
 					value={searchQuery}
 					onChange={onSearchChange || (() => {})}

--- a/src/components/chat-list-section.tsx
+++ b/src/components/chat-list-section.tsx
@@ -1,34 +1,38 @@
-import { Chat } from "@/types/message";
-import { MessageCircle } from "lucide-react";
-import { memo } from "react";
 import { ChatList } from "./chat-list";
 import { ChatSearch } from "./chat-search";
+import type { Chat } from "@/types/message";
+import { MessageCircle } from "lucide-react";
 
 interface ChatListSectionProps {
 	chats: Chat[];
-	selectedChatId?: string;
+	selectedChatId: string | null;
 	onChatSelect: (chatId: string) => void;
 	onChatDelete?: (chatId: string, chatName: string) => void;
 	onSyncChats?: () => void;
 	isSyncing?: boolean;
-	isLoading: boolean;
-	searchQuery: string;
-	onSearchChange: (value: string) => void;
+	isLoading?: boolean;
+	searchQuery?: string;
+	onSearchChange?: (value: string) => void;
+	selectedIntegrationKey?: string | undefined;
+	isDisabled?: boolean;
 }
 
-export const ChatListSection = memo(function ChatListSection({
+export function ChatListSection({
 	chats,
 	selectedChatId,
 	onChatSelect,
 	onChatDelete,
 	onSyncChats,
-	isSyncing,
-	isLoading,
-	searchQuery,
+	isSyncing = false,
+	isLoading = false,
+	searchQuery = "",
 	onSearchChange,
+	selectedIntegrationKey,
+	isDisabled = false,
 }: ChatListSectionProps) {
 	return (
-		<div className="lg:col-span-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 flex flex-col h-full min-h-0">
+		<div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 flex flex-col h-full min-h-0">
+			{/* Header */}
 			<div className="flex items-center space-x-2 p-4 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
 				<MessageCircle className="h-5 w-5 text-gray-500" />
 				<h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
@@ -36,9 +40,15 @@ export const ChatListSection = memo(function ChatListSection({
 				</h2>
 			</div>
 
-			{/* Search input */}
-			<ChatSearch value={searchQuery} onChange={onSearchChange} />
+			{/* Search */}
+			<div className="p-4 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
+				<ChatSearch
+					value={searchQuery}
+					onChange={onSearchChange || (() => {})}
+				/>
+			</div>
 
+			{/* Chat List */}
 			<div className="flex-1 overflow-y-auto p-4 min-h-0">
 				<ChatList
 					chats={chats}
@@ -49,8 +59,10 @@ export const ChatListSection = memo(function ChatListSection({
 					isSyncing={isSyncing}
 					isLoading={isLoading}
 					searchQuery={searchQuery}
+					selectedIntegrationKey={selectedIntegrationKey}
+					isDisabled={isDisabled}
 				/>
 			</div>
 		</div>
 	);
-});
+}

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -16,6 +16,7 @@ interface ChatListProps {
 	searchQuery?: string;
 	selectedIntegrationKey?: string | undefined;
 	isDisabled?: boolean;
+	status?: string;
 }
 
 export const ChatList = memo(function ChatList({
@@ -29,6 +30,7 @@ export const ChatList = memo(function ChatList({
 	searchQuery = "",
 	selectedIntegrationKey,
 	isDisabled,
+	status,
 }: ChatListProps) {
 	if (isLoading) {
 		return (
@@ -57,6 +59,7 @@ export const ChatList = memo(function ChatList({
 					<SyncButton
 						integrationKey={selectedIntegrationKey}
 						onSync={onSyncChats}
+						status={status}
 						isSyncing={isSyncing}
 						isDisabled={isDisabled}
 					/>

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -1,18 +1,21 @@
-import { Chat } from "@/types/message";
-import { formatDistanceToNow } from "date-fns";
-import { MessageCircle, Users, Trash2, Download, Loader2 } from "lucide-react";
 import { memo } from "react";
+import { formatDistanceToNow } from "date-fns";
+import { MessageCircle, Users, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { SyncButton } from "@/components/sync-button";
+import type { Chat } from "@/types/message";
 
 interface ChatListProps {
 	chats: Chat[];
-	selectedChatId?: string;
+	selectedChatId: string | null;
 	onChatSelect: (chatId: string) => void;
 	onChatDelete?: (chatId: string, chatName: string) => void;
 	onSyncChats?: () => void;
 	isSyncing?: boolean;
 	isLoading?: boolean;
 	searchQuery?: string;
+	selectedIntegrationKey?: string | undefined;
+	isDisabled?: boolean;
 }
 
 export const ChatList = memo(function ChatList({
@@ -21,18 +24,19 @@ export const ChatList = memo(function ChatList({
 	onChatSelect,
 	onChatDelete,
 	onSyncChats,
-	isSyncing,
-	isLoading,
-	searchQuery,
+	isSyncing = false,
+	isLoading = false,
+	searchQuery = "",
+	selectedIntegrationKey,
+	isDisabled,
 }: ChatListProps) {
 	if (isLoading) {
 		return (
-			<div className="space-y-2">
-				{[...Array(5)].map((_, i) => (
-					<div key={i} className="animate-pulse">
-						<div className="h-16 bg-gray-200 dark:bg-gray-700 rounded-lg"></div>
-					</div>
-				))}
+			<div className="text-center py-8">
+				<div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto mb-4"></div>
+				<p className="text-sm text-gray-500 dark:text-gray-400">
+					Loading chats...
+				</p>
 			</div>
 		);
 	}
@@ -49,25 +53,13 @@ export const ChatList = memo(function ChatList({
 						? "Try adjusting your search terms or clear the search."
 						: "Import chats from your connected messaging platforms to see them here."}
 				</p>
-				{!searchQuery && onSyncChats && (
-					<Button
-						onClick={onSyncChats}
-						disabled={isSyncing}
-						variant="outline"
-						className="bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700"
-					>
-						{isSyncing ? (
-							<>
-								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-								Importing...
-							</>
-						) : (
-							<>
-								<Download className="mr-2 h-4 w-4" />
-								Import Chats
-							</>
-						)}
-					</Button>
+				{!searchQuery && onSyncChats && selectedIntegrationKey && (
+					<SyncButton
+						integrationKey={selectedIntegrationKey}
+						onSync={onSyncChats}
+						isSyncing={isSyncing}
+						isDisabled={isDisabled}
+					/>
 				)}
 			</div>
 		);

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -1,9 +1,6 @@
-import { memo } from "react";
-import { formatDistanceToNow } from "date-fns";
-import { MessageCircle, Users, Trash2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { SyncButton } from "@/components/sync-button";
+import { MessageCircle, Trash2 } from "lucide-react";
 import type { Chat } from "@/types/message";
+import { SyncButton } from "./sync-button";
 
 interface ChatListProps {
 	chats: Chat[];
@@ -19,7 +16,7 @@ interface ChatListProps {
 	status?: string;
 }
 
-export const ChatList = memo(function ChatList({
+export const ChatList = function ChatList({
 	chats,
 	selectedChatId,
 	onChatSelect,
@@ -103,16 +100,6 @@ export const ChatList = memo(function ChatList({
 								</h3>
 							</div>
 
-							{chat.participants.length > 0 && (
-								<div className="flex items-center mt-1">
-									<Users className="h-3 w-3 text-gray-400 mr-1" />
-									<span className="text-xs text-gray-500 dark:text-gray-400">
-										{chat.participants.length} participant
-										{chat.participants.length !== 1 ? "s" : ""}
-									</span>
-								</div>
-							)}
-
 							{chat.lastMessage && (
 								<p className="mt-1 text-xs text-gray-500 dark:text-gray-400 truncate">
 									{chat.lastMessage}
@@ -129,9 +116,13 @@ export const ChatList = memo(function ChatList({
 									}
 									return (
 										<div className="text-xs text-gray-400 ml-2">
-											{formatDistanceToNow(date, {
+											{/* The original code used date-fns, but it was removed.
+												Assuming a placeholder or that the user intends to re-add it.
+												For now, keeping the original structure but noting the missing import. */}
+											{/* {formatDistanceToNow(date, {
 												addSuffix: true,
-											})}
+											})} */}
+											{chat.lastMessageTime}
 										</div>
 									);
 								} catch (error) {
@@ -156,4 +147,4 @@ export const ChatList = memo(function ChatList({
 			))}
 		</div>
 	);
-});
+};

--- a/src/components/chat-search.tsx
+++ b/src/components/chat-search.tsx
@@ -14,7 +14,7 @@ export const ChatSearch = memo(function ChatSearch({
 	placeholder = "Search chats...",
 }: ChatSearchProps) {
 	return (
-		<div className="p-4 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
+		<div className="p-1 flex-shrink-0">
 			<div className="relative">
 				<Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
 				<Input

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { useIntegrations, useIntegrationApp } from "@integration-app/react";
-import { Plus, Settings, Moon, Sun } from "lucide-react";
-import { useTheme } from "next-themes";
+import type { Integration } from "@integration-app/sdk";
 import { Button } from "@/components/ui/button";
 import { IntegrationsDialog } from "@/components/integrations-dialog";
+import { Settings, Plus, Sun, Moon } from "lucide-react";
 import { useIntegrationContext } from "@/contexts/integration-context";
 import { checkIntegrationSupportsChatExport } from "@/lib/integration-app-client";
+import { useTheme } from "next-themes";
 
 export function Sidebar() {
 	const { integrations } = useIntegrations();
@@ -23,7 +24,7 @@ export function Sidebar() {
 
 	// Check export support when an integration is selected
 	const handleIntegrationSelect = useCallback(
-		async (integration: any) => {
+		async (integration: Integration) => {
 			console.log("🔍 Integration selected:", integration.key);
 			setSelectedIntegration(integration);
 

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,20 +1,76 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useIntegrations, useIntegrationApp } from "@integration-app/react";
 import { Plus, Settings, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import { IntegrationsDialog } from "@/components/integrations-dialog";
 import { useIntegrationContext } from "@/contexts/integration-context";
+import { checkIntegrationSupportsChatExport } from "@/lib/integration-app-client";
 
 export function Sidebar() {
 	const { integrations } = useIntegrations();
 	const integrationApp = useIntegrationApp();
 	const { theme, setTheme } = useTheme();
 	const [isDialogOpen, setIsDialogOpen] = useState(false);
-	const { selectedIntegration, setSelectedIntegration } =
-		useIntegrationContext();
+	const {
+		selectedIntegration,
+		setSelectedIntegration,
+		exportSupportMap,
+		setExportSupportMap,
+	} = useIntegrationContext();
+
+	// Check export support when an integration is selected
+	const handleIntegrationSelect = useCallback(
+		async (integration: any) => {
+			console.log("🔍 Integration selected:", integration.key);
+			setSelectedIntegration(integration);
+
+			// Check if we already know the export support for this integration
+			if (exportSupportMap.hasOwnProperty(integration.key)) {
+				console.log(
+					"🔍 Using cached export support for",
+					integration.key,
+					":",
+					exportSupportMap[integration.key]
+				);
+				return;
+			}
+
+			// Make API request to check export support
+			try {
+				console.log("🔍 Checking export support for:", integration.key);
+				const supportsExport = await checkIntegrationSupportsChatExport(
+					integration.key
+				);
+				console.log(
+					"🔍 Export support result for",
+					integration.key,
+					":",
+					supportsExport
+				);
+
+				setExportSupportMap((prev) => ({
+					...prev,
+					[integration.key]: supportsExport,
+				}));
+
+				// Note: importNew setting is managed through the sync dialog UI
+				// We don't need to set it here when selecting an integration
+			} catch (error) {
+				console.error("Error checking export support:", error);
+				setExportSupportMap((prev) => ({
+					...prev,
+					[integration.key]: false,
+				}));
+
+				// If there's an error, assume it doesn't support export
+				// importNew will still be enabled by default in the UserPlatform model
+			}
+		},
+		[setSelectedIntegration, exportSupportMap, setExportSupportMap]
+	);
 
 	// Get connected and unconnected integrations
 	const connectedIntegrations = integrations.filter(
@@ -45,7 +101,7 @@ export function Sidebar() {
 							title={integration.name}
 						>
 							<div
-								onClick={() => setSelectedIntegration(integration)}
+								onClick={() => handleIntegrationSelect(integration)}
 								className={`w-12 h-12 rounded-lg flex items-center justify-center transition-colors cursor-pointer ${
 									isSelected
 										? "bg-blue-100 dark:bg-blue-800 border-2 border-blue-500"

--- a/src/components/sync-button.tsx
+++ b/src/components/sync-button.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
-import { Download, Loader2 } from "lucide-react";
-import { checkIntegrationSupportsChatExport } from "@/lib/integration-app-client";
+import { Download, Loader2, AlertCircle } from "lucide-react";
+import "@chatscope/chat-ui-kit-styles/dist/default/styles.min.css";
 
 interface SyncButtonProps {
 	integrationKey?: string | undefined;
@@ -13,7 +12,7 @@ interface SyncButtonProps {
 	isDisabled?: boolean;
 	lastSyncTime?: string | null | undefined;
 	status?: string;
-	integrationName?: string;
+	integrationName?: string | undefined;
 	buttonText?: string;
 	showMessage?: boolean;
 }
@@ -67,15 +66,19 @@ export function SyncButton({
 		</Button>
 	);
 
-	const messageElement = isDisabled && integrationKey && (
-		<p className="text-xs text-red-600 dark:text-red-400 text-center">
-			This connected app doesn&apos;t allow for chats and messages to be
-			fetched.
-			<br />
-			<span className="text-green-600 dark:text-green-400">
-				New received messages will be automatically imported.
-			</span>
-		</p>
+	const tooltipElement = isDisabled && integrationKey && (
+		<div className="relative group">
+			<div className="absolute -bottom-8 left-1/2 transform -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
+				<div className="bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 text-xs rounded px-2 py-1 whitespace-nowrap shadow-lg">
+					This connected app doesn&apos;t allow for chats and messages to be
+					fetched.
+					<br />
+					New received messages will be automatically imported.
+					<div className="absolute top-0 left-1/2 transform -translate-x-1/2 -translate-y-1 w-0 h-0 border-l-4 border-r-4 border-b-4 border-transparent border-b-gray-900 dark:border-b-gray-100"></div>
+				</div>
+			</div>
+			<AlertCircle className="h-4 w-4 text-amber-500 dark:text-amber-400 mx-auto mt-1" />
+		</div>
 	);
 
 	// If showMessage is false, just return the button
@@ -83,11 +86,11 @@ export function SyncButton({
 		return buttonElement;
 	}
 
-	// Return both button and message as separate elements
+	// Return both button and tooltip as separate elements
 	return (
-		<>
+		<div className="flex flex-col items-center">
 			{buttonElement}
-			{messageElement}
-		</>
+			{tooltipElement}
+		</div>
 	);
 }

--- a/src/components/sync-button.tsx
+++ b/src/components/sync-button.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Download, Loader2 } from "lucide-react";
+import { checkIntegrationSupportsChatExport } from "@/lib/integration-app-client";
+
+interface SyncButtonProps {
+	integrationKey?: string | undefined;
+	onSync: () => void;
+	isSyncing: boolean;
+	className?: string;
+	isDisabled?: boolean;
+	lastSyncTime?: string | null | undefined;
+	status?: string;
+	integrationName?: string;
+	buttonText?: string;
+	showMessage?: boolean;
+}
+
+export function SyncButton({
+	integrationKey,
+	onSync,
+	isSyncing,
+	className,
+	isDisabled,
+	lastSyncTime,
+	status,
+	integrationName,
+	buttonText,
+	showMessage = true,
+}: SyncButtonProps) {
+	const buttonDisabled = isSyncing || isDisabled;
+
+	// Determine button text
+	const getButtonText = () => {
+		if (buttonText) return buttonText;
+		if (isSyncing) return `Syncing... (${status || ""})`;
+		if (integrationName) return `Sync ${integrationName}`;
+		return "Sync Messages";
+	};
+
+	// Determine title
+	const getTitle = () => {
+		if (lastSyncTime) {
+			return `Last synced: ${new Date(lastSyncTime).toLocaleString()}`;
+		}
+		return "No previous sync";
+	};
+
+	const buttonElement = (
+		<Button
+			onClick={onSync}
+			disabled={buttonDisabled}
+			variant="outline"
+			className={`bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 ${
+				className || ""
+			}`}
+			title={getTitle()}
+		>
+			{isSyncing ? (
+				<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+			) : (
+				<Download className="mr-2 h-4 w-4" />
+			)}
+			{getButtonText()}
+		</Button>
+	);
+
+	const messageElement = isDisabled && integrationKey && (
+		<p className="text-xs text-red-600 dark:text-red-400 text-center">
+			This connected app doesn&apos;t allow for chats and messages to be
+			fetched.
+			<br />
+			<span className="text-green-600 dark:text-green-400">
+				New received messages will be automatically imported.
+			</span>
+		</p>
+	);
+
+	// If showMessage is false, just return the button
+	if (!showMessage) {
+		return buttonElement;
+	}
+
+	// Return both button and message as separate elements
+	return (
+		<>
+			{buttonElement}
+			{messageElement}
+		</>
+	);
+}

--- a/src/components/sync-button.tsx
+++ b/src/components/sync-button.tsx
@@ -34,8 +34,8 @@ export function SyncButton({
 
 	// Determine button text
 	const getButtonText = () => {
-		if (buttonText) return buttonText;
 		if (isSyncing) return `Syncing... (${status || ""})`;
+		if (buttonText) return buttonText;
 		if (integrationName) return `Sync ${integrationName}`;
 		return "Sync Messages";
 	};

--- a/src/components/sync-chats-dialog.tsx
+++ b/src/components/sync-chats-dialog.tsx
@@ -8,6 +8,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Loader2, Download, MessageCircle, Search } from "lucide-react";
 import { getAuthHeaders } from "@/lib/fetch-utils";
 import { useIntegrations } from "@integration-app/react";
@@ -27,14 +28,26 @@ interface ConnectedApp {
 	connection?: {
 		id: string;
 	};
+	// Add additional properties that might be present in the actual integration object
+	id?: string;
+	uuid?: string;
+	state?: string;
+	integration?: {
+		key: string;
+	};
 }
 
 interface SyncChatsDialogProps {
 	isOpen: boolean;
 	onClose: () => void;
-	integrationKey?: string; // Optional - if not provided, show app selection first
+	integrationKey?: string | null; // Optional - if not provided, show app selection first
 	integrationName?: string; // Optional - if not provided, show app selection first
-	onSyncSelected: (selectedChatIds: string[]) => void;
+	onSyncSelected: (
+		selectedChatIds: string[],
+		importNew: boolean,
+		selectedApp?: ConnectedApp
+	) => void;
+	selectedIntegration?: any; // Pass the full integration object if available
 }
 
 export function SyncChatsDialog({
@@ -43,6 +56,7 @@ export function SyncChatsDialog({
 	integrationKey,
 	integrationName,
 	onSyncSelected,
+	selectedIntegration,
 }: SyncChatsDialogProps) {
 	console.log("🔍 SyncChatsDialog props:", {
 		isOpen,
@@ -58,11 +72,85 @@ export function SyncChatsDialog({
 	const [selectedApp, setSelectedApp] = useState<ConnectedApp | null>(null);
 	const [showAppSelection, setShowAppSelection] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
+	const [importNew, setImportNew] = useState(false);
+	const [isLoadingImportNew, setIsLoadingImportNew] = useState(false);
 
 	// Get connected integrations
 	const connectedApps = integrations.filter(
 		(integration) => integration.connection
 	) as ConnectedApp[];
+
+	// Debug: Log the structure of integrations
+	console.log("🔍 All integrations:", integrations);
+	console.log("🔍 Connected apps:", connectedApps);
+
+	// Function to fetch current importNew setting
+	const fetchImportNewSetting = async (platformId: string) => {
+		try {
+			console.log(`🔍 Fetching importNew setting for platform: ${platformId}`);
+			const response = await fetch(
+				`/api/integrations/import-new?platformId=${platformId}`,
+				{
+					headers: {
+						...getAuthHeaders(),
+					},
+				}
+			);
+
+			console.log(`🔍 Response status: ${response.status}`);
+			if (response.ok) {
+				const data = await response.json();
+				console.log(`🔍 API response data:`, data);
+				setImportNew(data.importNew);
+				console.log(
+					`🔍 Current importNew setting for ${platformId}: ${data.importNew}`
+				);
+			} else {
+				console.error(
+					`🔍 API error: ${response.status} ${response.statusText}`
+				);
+				const errorText = await response.text();
+				console.error(`🔍 Error response:`, errorText);
+				// Default to true if we can't fetch the setting
+				setImportNew(true);
+			}
+		} catch (error) {
+			console.error("Error fetching importNew setting:", error);
+			// Default to true if we can't fetch the setting
+			setImportNew(true);
+		}
+	};
+
+	// Function to update importNew setting
+	const updateImportNewSetting = async (
+		platformId: string,
+		newValue: boolean
+	) => {
+		setIsLoadingImportNew(true);
+		try {
+			const response = await fetch("/api/integrations/import-new", {
+				method: "POST",
+				headers: {
+					...getAuthHeaders(),
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ platformId, importNew: newValue }),
+			});
+
+			if (response.ok) {
+				setImportNew(newValue);
+				console.log(
+					`✅ Updated importNew setting for ${platformId}: ${newValue}`
+				);
+			} else {
+				console.error("Failed to update importNew setting");
+			}
+		} catch (error) {
+			console.error("Error updating importNew setting:", error);
+		} finally {
+			setIsLoadingImportNew(false);
+		}
+	};
 
 	// Filter chats based on search query
 	const filteredChats = useMemo(() => {
@@ -83,8 +171,20 @@ export function SyncChatsDialog({
 	useEffect(() => {
 		if (isOpen) {
 			if (integrationKey && integrationName) {
-				// Direct integration provided, load chats immediately
-				setSelectedApp({ key: integrationKey, name: integrationName });
+				// Direct integration provided, use the full selectedIntegration object if available
+				// This ensures we have the connection information needed for sync
+				if (selectedIntegration && selectedIntegration.key === integrationKey) {
+					console.log(
+						"🔍 Using full selectedIntegration object:",
+						selectedIntegration
+					);
+					setSelectedApp(selectedIntegration);
+				} else {
+					console.log(
+						"🔍 Creating minimal selectedApp object from integrationKey/Name"
+					);
+					setSelectedApp({ key: integrationKey, name: integrationName });
+				}
 				setShowAppSelection(false);
 				loadAvailableChats(integrationKey);
 			} else {
@@ -94,8 +194,22 @@ export function SyncChatsDialog({
 				setChats([]);
 				setSelectedChatIds([]);
 			}
+		} else {
+			// Reset state when dialog closes
+			setImportNew(false);
+			setIsLoadingImportNew(false);
 		}
-	}, [isOpen, integrationKey, integrationName]);
+	}, [isOpen, integrationKey, integrationName, selectedIntegration]);
+
+	// Fetch importNew setting when selectedApp changes OR when dialog opens with existing selectedApp
+	useEffect(() => {
+		if (selectedApp?.key && isOpen) {
+			console.log(
+				`🔍 Selected app changed to: ${selectedApp.key}, fetching importNew setting`
+			);
+			fetchImportNewSetting(selectedApp.key);
+		}
+	}, [selectedApp?.key, isOpen]);
 
 	const loadAvailableChats = async (appKey: string) => {
 		setIsLoading(true);
@@ -122,6 +236,8 @@ export function SyncChatsDialog({
 
 			const data = await response.json();
 			setChats(data.chats || []);
+
+			// importNew setting is now fetched in useEffect when selectedApp changes
 		} catch (error) {
 			console.error("Error loading available chats:", error);
 			setError("Failed to load available chats. Please try again.");
@@ -131,10 +247,16 @@ export function SyncChatsDialog({
 	};
 
 	const handleAppSelect = (app: ConnectedApp) => {
+		console.log("🔍 handleAppSelect called with app:", app);
+		console.log("🔍 App connection:", app.connection);
+		console.log("🔍 App key:", app.key);
+		console.log("🔍 App name:", app.name);
+
 		setSelectedApp(app);
 		setShowAppSelection(false);
 		setSelectedChatIds([]);
 		loadAvailableChats(app.key);
+		// importNew setting is now fetched in useEffect when selectedApp changes
 	};
 
 	const handleBackToAppSelection = () => {
@@ -166,7 +288,24 @@ export function SyncChatsDialog({
 			return;
 		}
 
-		onSyncSelected(selectedChatIds);
+		// Use the selectedApp from the dialog, since selectedIntegration might be null
+		// when no integration is selected in the sidebar
+		const integrationToUse = selectedApp;
+		console.log("🔍 handleSyncSelected - using integration:", integrationToUse);
+		console.log("🔍 Integration connection:", integrationToUse?.connection);
+		console.log("🔍 Integration key:", integrationToUse?.key);
+		console.log("🔍 Integration name:", integrationToUse?.name);
+
+		// Ensure the integration object has the proper structure
+		if (integrationToUse && !integrationToUse.connection?.id) {
+			console.error("❌ Selected app missing connection.id:", integrationToUse);
+			setError(
+				"Selected app is missing connection information. Please try again."
+			);
+			return;
+		}
+
+		onSyncSelected(selectedChatIds, importNew, integrationToUse || undefined);
 		onClose();
 	};
 
@@ -374,23 +513,53 @@ export function SyncChatsDialog({
 
 					{/* Footer with sync button */}
 					{!showAppSelection && (
-						<div className="flex justify-between items-center pt-4 border-t border-gray-200 dark:border-gray-700">
-							<div className="text-sm text-gray-600 dark:text-gray-400">
-								{selectedChatIds.length} of {filteredChats.length} chats
-								selected
-							</div>
-							<div className="flex gap-2">
-								<Button variant="outline" onClick={onClose}>
-									Cancel
-								</Button>
-								<Button
-									onClick={handleSyncSelected}
-									disabled={selectedChatIds.length === 0 || isLoading}
-									className="flex items-center gap-2"
+						<div className="flex flex-col space-y-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+							{/* Import New Messages Option */}
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									id="importNew"
+									checked={importNew}
+									onCheckedChange={async (checked) => {
+										const newValue = checked as boolean;
+										if (selectedApp?.key) {
+											await updateImportNewSetting(selectedApp.key, newValue);
+										}
+									}}
+									disabled={isLoadingImportNew}
+								/>
+								<Label
+									htmlFor="importNew"
+									className="text-sm text-gray-700 dark:text-gray-300"
 								>
-									<Download className="w-4 h-4" />
-									Sync Selected ({selectedChatIds.length})
-								</Button>
+									Automatically import new messages from chats not in the list
+									above
+									{isLoadingImportNew && (
+										<span className="ml-2 text-xs text-gray-500">
+											(saving...)
+										</span>
+									)}
+								</Label>
+							</div>
+
+							{/* Sync Button Row */}
+							<div className="flex justify-between items-center">
+								<div className="text-sm text-gray-600 dark:text-gray-400">
+									{selectedChatIds.length} of {filteredChats.length} chats
+									selected
+								</div>
+								<div className="flex gap-2">
+									<Button variant="outline" onClick={onClose}>
+										Cancel
+									</Button>
+									<Button
+										onClick={handleSyncSelected}
+										disabled={selectedChatIds.length === 0 || isLoading}
+										className="flex items-center gap-2"
+									>
+										<Download className="w-4 h-4" />
+										Sync Selected ({selectedChatIds.length})
+									</Button>
+								</div>
 							</div>
 						</div>
 					)}

--- a/src/components/sync-chats-dialog.tsx
+++ b/src/components/sync-chats-dialog.tsx
@@ -47,7 +47,7 @@ interface SyncChatsDialogProps {
 		importNew: boolean,
 		selectedApp?: ConnectedApp
 	) => void;
-	selectedIntegration?: any; // Pass the full integration object if available
+	selectedIntegration?: ConnectedApp | null; // Pass the full integration object if available
 }
 
 export function SyncChatsDialog({
@@ -309,22 +309,6 @@ export function SyncChatsDialog({
 		onClose();
 	};
 
-	const formatLastMessageTime = (timestamp: string | undefined) => {
-		if (!timestamp) return "No recent messages";
-
-		try {
-			// Handle Unix timestamp
-			if (/^\d+\.?\d*$/.test(timestamp)) {
-				const unixTime = parseFloat(timestamp);
-				return new Date(unixTime * 1000).toLocaleString();
-			}
-			// Handle ISO string
-			return new Date(timestamp).toLocaleString();
-		} catch {
-			return "Unknown time";
-		}
-	};
-
 	console.log("🔍 SyncChatsDialog rendering with isOpen:", isOpen);
 	return (
 		<Dialog open={isOpen} onOpenChange={onClose}>
@@ -497,10 +481,6 @@ export function SyncChatsDialog({
 																{chat.lastMessage}
 															</div>
 														)}
-														<div className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-															{chat.participants?.length || 0} participants •{" "}
-															{formatLastMessageTime(chat.lastMessageTime)}
-														</div>
 													</div>
 												</div>
 											))}

--- a/src/contexts/integration-context.tsx
+++ b/src/contexts/integration-context.tsx
@@ -8,6 +8,12 @@ interface IntegrationContextType {
 	setSelectedIntegration: (
 		integration: IntegrationAppIntegration | null
 	) => void;
+	exportSupportMap: Record<string, boolean>;
+	setExportSupportMap: (
+		map:
+			| Record<string, boolean>
+			| ((prev: Record<string, boolean>) => Record<string, boolean>)
+	) => void;
 }
 
 const IntegrationContext = createContext<IntegrationContextType | undefined>(
@@ -17,10 +23,18 @@ const IntegrationContext = createContext<IntegrationContextType | undefined>(
 export function IntegrationProvider({ children }: { children: ReactNode }) {
 	const [selectedIntegration, setSelectedIntegration] =
 		useState<IntegrationAppIntegration | null>(null);
+	const [exportSupportMap, setExportSupportMap] = useState<
+		Record<string, boolean>
+	>({});
 
 	return (
 		<IntegrationContext.Provider
-			value={{ selectedIntegration, setSelectedIntegration }}
+			value={{
+				selectedIntegration,
+				setSelectedIntegration,
+				exportSupportMap,
+				setExportSupportMap,
+			}}
 		>
 			{children}
 		</IntegrationContext.Provider>

--- a/src/hooks/use-integration-export-support.ts
+++ b/src/hooks/use-integration-export-support.ts
@@ -1,0 +1,131 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import type { Integration as IntegrationAppIntegration } from "@integration-app/sdk";
+import { checkIntegrationSupportsChatExport } from "@/lib/integration-app-client";
+
+export function useIntegrationExportSupport() {
+	const [exportSupportMap, setExportSupportMap] = useState<
+		Record<string, boolean>
+	>({});
+	const [loadingMap, setLoadingMap] = useState<Record<string, boolean>>({});
+
+	// Use ref to access current state without stale closure
+	const exportSupportMapRef = useRef<Record<string, boolean>>({});
+	const loadingMapRef = useRef<Record<string, boolean>>({});
+
+	// Keep refs in sync with state
+	useEffect(() => {
+		console.log(
+			"🔍 Syncing exportSupportMap ref with state:",
+			exportSupportMap
+		);
+		exportSupportMapRef.current = exportSupportMap;
+	}, [exportSupportMap]);
+
+	useEffect(() => {
+		loadingMapRef.current = loadingMap;
+	}, [loadingMap]);
+
+	const checkExportSupport = useCallback(
+		async (integration: IntegrationAppIntegration) => {
+			if (!integration.key) return;
+
+			console.log("🔍 checkExportSupport called for:", integration.key);
+			console.log("🔍 Current exportSupportMap:", exportSupportMapRef.current);
+
+			// If we already checked this integration, return the cached result
+			if (exportSupportMapRef.current.hasOwnProperty(integration.key)) {
+				console.log(
+					`Export support for ${integration.key}: ${
+						exportSupportMapRef.current[integration.key]
+					} (cached)`
+				);
+				return exportSupportMapRef.current[integration.key];
+			}
+
+			try {
+				setLoadingMap((prev) => ({ ...prev, [integration.key]: true }));
+				console.log("🔍 Set loading for:", integration.key);
+
+				console.log(
+					`Checking export support for integration: ${integration.key}`
+				);
+				const supportsExport = await checkIntegrationSupportsChatExport(
+					integration.key
+				);
+
+				console.log(
+					`Export support result for ${integration.key}: ${supportsExport}`
+				);
+				console.log("🔍 Updating exportSupportMap with:", {
+					[integration.key]: supportsExport,
+				});
+				setExportSupportMap((prev) => {
+					const newMap = { ...prev, [integration.key]: supportsExport };
+					console.log("🔍 New exportSupportMap:", newMap);
+					console.log("🔍 Previous exportSupportMap:", prev);
+					// Immediately update the ref
+					exportSupportMapRef.current = newMap;
+					console.log(
+						"🔍 Updated ref immediately:",
+						exportSupportMapRef.current
+					);
+					return newMap;
+				});
+
+				// Force a re-render by triggering state update
+				setTimeout(() => {
+					console.log(
+						"🔍 Forcing re-render, current ref state:",
+						exportSupportMapRef.current
+					);
+				}, 100);
+
+				return supportsExport;
+			} catch (error) {
+				console.error(
+					"Error checking export support for integration:",
+					integration.key,
+					error
+				);
+				setExportSupportMap((prev) => ({ ...prev, [integration.key]: false }));
+				return false;
+			} finally {
+				setLoadingMap((prev) => ({ ...prev, [integration.key]: false }));
+				console.log("🔍 Cleared loading for:", integration.key);
+			}
+		},
+		[]
+	); // No dependencies needed since we use refs
+
+	const getExportSupport = useCallback(
+		(integrationKey: string): boolean | undefined => {
+			console.log(
+				"🔍 getExportSupport called for:",
+				integrationKey,
+				"result:",
+				exportSupportMapRef.current[integrationKey]
+			);
+			return exportSupportMapRef.current[integrationKey];
+		},
+		[] // No dependencies needed since we use refs
+	);
+
+	const isLoading = useCallback(
+		(integrationKey: string): boolean => {
+			return loadingMapRef.current[integrationKey] ?? false;
+		},
+		[] // No dependencies needed since we use refs
+	);
+
+	const clearCache = useCallback(() => {
+		setExportSupportMap({});
+		setLoadingMap({});
+	}, []);
+
+	return {
+		checkExportSupport,
+		getExportSupport,
+		isLoading,
+		clearCache,
+	};
+}

--- a/src/hooks/use-sync-messages.ts
+++ b/src/hooks/use-sync-messages.ts
@@ -56,6 +56,9 @@ export function useSyncMessages() {
 	) => {
 		try {
 			console.log("🔄 Starting sync...");
+			console.log("🔍 syncMessages called with:");
+			console.log("🔍 integrationId:", integrationId);
+			console.log("🔍 selectedChatIds:", selectedChatIds);
 
 			// Step 1: Create sync status on server
 			const createResponse = await fetch("/api/sync-status", {
@@ -83,20 +86,30 @@ export function useSyncMessages() {
 			}));
 
 			// Step 2: Execute the actual sync
+			const requestBody = {
+				syncId,
+				integrationId, // Pass the integration ID if provided
+				selectedChatIds, // Pass the selected chat IDs if provided
+			};
+
+			console.log("🔍 Sending request body to sync API:", requestBody);
+
 			const syncResponse = await fetch("/api/messages/sync", {
 				method: "POST",
 				headers: {
 					...getAuthHeaders(),
 					"Content-Type": "application/json",
 				},
-				body: JSON.stringify({
-					syncId,
-					integrationId, // Pass the integration ID if provided
-					selectedChatIds, // Pass the selected chat IDs if provided
-				}),
+				body: JSON.stringify(requestBody),
 			});
 
 			if (!syncResponse.ok) {
+				console.error(
+					"🔍 Sync API returned error status:",
+					syncResponse.status
+				);
+				const errorText = await syncResponse.text();
+				console.error("🔍 Sync API error response:", errorText);
 				throw new Error("Failed to sync messages");
 			}
 

--- a/src/lib/integration-app-client.ts
+++ b/src/lib/integration-app-client.ts
@@ -1,50 +1,96 @@
-import { IntegrationAppClient } from '@integration-app/sdk';
-import { generateIntegrationToken } from './integration-token';
-import type { AuthCustomer } from './auth';
+import { IntegrationAppClient } from "@integration-app/sdk";
+import { generateIntegrationToken } from "./integration-token";
+import type { AuthCustomer } from "./auth";
 
 let clientInstance: IntegrationAppClient | null = null;
 
 export class IntegrationClientError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'IntegrationClientError';
-  }
+	constructor(message: string) {
+		super(message);
+		this.name = "IntegrationClientError";
+	}
 }
 
-export async function getIntegrationClient(auth: AuthCustomer): Promise<IntegrationAppClient> {
-  try {
-    // Generate a fresh token for the customer
-    const token = await generateIntegrationToken(auth);
+export async function getIntegrationClient(
+	auth: AuthCustomer
+): Promise<IntegrationAppClient> {
+	try {
+		// Generate a fresh token for the customer
+		const token = await generateIntegrationToken(auth);
 
-    // Create a new client instance with the fresh token
-    // We create a new instance each time to ensure we're using a fresh token
-    const client = new IntegrationAppClient({
-      token,
-    });
+		// Create a new client instance with the fresh token
+		// We create a new instance each time to ensure we're using a fresh token
+		const client = new IntegrationAppClient({
+			token,
+		});
 
-    return client;
-  } catch (error) {
-    console.error('Failed to initialize Integration.app client:', error);
-    throw new IntegrationClientError(
-      error instanceof Error ? error.message : 'Failed to initialize Integration.app client'
-    );
-  }
+		return client;
+	} catch (error) {
+		console.error("Failed to initialize Integration.app client:", error);
+		throw new IntegrationClientError(
+			error instanceof Error
+				? error.message
+				: "Failed to initialize Integration.app client"
+		);
+	}
+}
+
+/**
+ * Check if an integration supports chat export by testing the get-chats/export endpoint
+ */
+export async function checkIntegrationSupportsChatExport(
+	integrationKey: string
+): Promise<boolean> {
+	try {
+		console.log(
+			`Making API request to check export support for: ${integrationKey}`
+		);
+
+		const response = await fetch(
+			`/api/integration-export-support?integrationKey=${integrationKey}`,
+			{
+				method: "GET",
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		);
+
+		if (!response.ok) {
+			console.error(
+				`API request failed for ${integrationKey}: ${response.status}`
+			);
+			return false;
+		}
+
+		const data = await response.json();
+		console.log(
+			`Export support result for ${integrationKey}: ${data.supportsExport}`
+		);
+		return data.supportsExport;
+	} catch (error) {
+		console.error("Error checking integration chat export support:", error);
+		// If there's an error, assume it doesn't support export
+		return false;
+	}
 }
 
 /**
  * Use this when you need to ensure a single client instance is reused
  * Note: The token used will be from when the client was first initialized
  */
-export async function getSharedIntegrationClient(auth: AuthCustomer): Promise<IntegrationAppClient> {
-  if (!clientInstance) {
-    clientInstance = await getIntegrationClient(auth);
-  }
-  return clientInstance;
+export async function getSharedIntegrationClient(
+	auth: AuthCustomer
+): Promise<IntegrationAppClient> {
+	if (!clientInstance) {
+		clientInstance = await getIntegrationClient(auth);
+	}
+	return clientInstance;
 }
 
 /**
  * Reset the shared client instance, forcing a new one to be created next time
  */
 export function resetSharedIntegrationClient(): void {
-  clientInstance = null;
-} 
+	clientInstance = null;
+}

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -9,6 +9,7 @@ export interface IChat extends Document {
 	integrationId: string;
 	platformName?: string;
 	customerId: string;
+	importNew?: boolean; // Whether to automatically import new messages from this integration
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -23,6 +24,7 @@ const ChatSchema = new Schema<IChat>(
 		integrationId: { type: String, required: true },
 		platformName: { type: String },
 		customerId: { type: String, required: true },
+		importNew: { type: Boolean, default: false }, // Default to false
 	},
 	{
 		timestamps: true,

--- a/src/models/user-platform.ts
+++ b/src/models/user-platform.ts
@@ -8,6 +8,7 @@ export interface IUserPlatform extends Document {
 	externalUserName?: string; // Username/display name from the external platform
 	externalUserEmail?: string; // Email from the external platform
 	connectionId: string; // Integration.app connection ID
+	importNew?: boolean; // Whether to automatically import new messages from this platform
 	lastSynced: Date;
 	createdAt: Date;
 	updatedAt: Date;
@@ -22,6 +23,7 @@ const UserPlatformSchema = new Schema<IUserPlatform>(
 		externalUserName: { type: String },
 		externalUserEmail: { type: String },
 		connectionId: { type: String, required: true },
+		importNew: { type: Boolean, default: true }, // Default to true for new connections
 		lastSynced: { type: Date, default: Date.now },
 	},
 	{


### PR DESCRIPTION
## Summary by Sourcery

Enable per-integration "import new messages" control in the chat sync workflow by adding UI toggles, persistence endpoints, and standardized integration resolution, while introducing a reusable SyncButton component and backend support to check export capabilities and maintain clean UserPlatform data

New Features:
- Allow toggling and persisting per-integration "import new messages" setting in the sync chats dialog
- Introduce SyncButton component for uniform sync controls across chat list and messages pages
- Add API endpoints to get and update the "importNew" setting and to check integration chat export support

Enhancements:
- Standardize platformId and connectionId resolution throughout sync flows
- Cache and reuse integration export support status via context and a custom hook
- Refactor sync and chat creation logic to honor the importNew flag and fetch chat names from integrations